### PR TITLE
Handle errors to prevent server crashes

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,6 +77,12 @@ app.get('/sse', function (req, res) {
 		.then(() => cache.set(tweet_id, { article_info: article_info, sentiment_analysis: sentiment_analysis, related_articles: related_articles }))
 		.then(() => res.write('event: close\ndata:\n\n\n'))
 		.then(() => res.end())
+		.catch(error => {
+			console.error(error)
+			res.write(`data: ${JSON.stringify({ tweet_id: tweet_id, type: 'error', content: error.message })}\n\n`)
+			res.write('event: close\ndata:\n\n\n')
+			res.end()
+		})
 
 	req.on('close', () => {
 		res.write('event: close\ndata:\n\n\n')


### PR DESCRIPTION
* Catch all errors in the Promise chain at once
  * We could've tried to catch the errors at each stage in the process, but it makes the code harder to read and adds unnecessary complexity to the code. If there's an error, there's an error, and the end-user doesn't really need to know at what stage the error is from.
* Return error message to client as type `error`. We could choose how we want to handle these error messages. We can display a generic error message or we can surface the specific error message (probably the former since the latter is pretty useless to the end-user).
* Log the error details in the server logs using `console.error`. This should make it easier to view and filter the logs.