### PR TITLE
Improve date and image parsing

### DIFF
--- a/document_parser.js
+++ b/document_parser.js
@@ -20,8 +20,10 @@ const getDateFromPage = ($) => {
 		json_ld_date_published = json_ld.datePublished
 	} catch (e) {}
 
-	let article_modified_time = $('meta[property="article:modified_time"]').attr('content')
-	let article_published_time = $('meta[property="article:published_time"]').attr('content')
+	let article_modified_time1 = $('meta[property="article:modified_time"]').attr('content')
+	let article_published_time1 = $('meta[property="article:published_time"]').attr('content')
+	let article_modified_time2 = $('meta[name="article:modified_time"]').attr('content')
+	let article_published_time2 = $('meta[name="article:published_time"]').attr('content')
 	let article_modified = $('meta[property="article:modified"]').attr('content')
 	let article_published1 = $('meta[property="article:published"]').attr('content')
 	let article_published2 = $('meta[name="article.published"]').attr('content')
@@ -30,7 +32,7 @@ const getDateFromPage = ($) => {
 	let pubdate = $('meta[name="pubdate"]').attr('content')
 	let last_modified = $('meta[name="last-modified"]').attr('content')
 
-	return json_ld_date_modified || json_ld_date_published || article_modified_time || article_published_time || article_modified || article_published1 || article_published2 || bt_pubDate || dc_date_issued || pubdate || last_modified
+	return json_ld_date_modified || json_ld_date_published || article_modified_time1 || article_published_time1 || article_modified_time2 || article_published_time2 || article_modified || article_published1 || article_published2 || bt_pubDate || dc_date_issued || pubdate || last_modified
 }
 
 const getImageFromPage = ($) => {


### PR DESCRIPTION
* Improve image parsing
  * Add `og:image` property for image URL as a fallback for missing Twitter tags. This is consistent with Twitter's documentation for fallbacks for missing tags.
* Improve date parsing
  * Add `last-modified` metadata name tag for last modified date
  * Add `meta[name="article:modified_time"]` and `meta[name="article:published_time"]`
  * Enhance JSON-LD parsing for CBC articles